### PR TITLE
Fixed an error where wx.App would not be created

### DIFF
--- a/gym_mupen64plus/envs/mupen64plus_env.py
+++ b/gym_mupen64plus/envs/mupen64plus_env.py
@@ -53,6 +53,7 @@ class Mupen64PlusEnv(gym.Env):
         self.reset_count = 0
         self.step_count = 0
         self.running = True
+        self.app = None
         self.episode_over = False
         self.numpy_array = None
         self.pixel_array = array.array('B', [0] * (config['SCR_W'] *
@@ -227,7 +228,7 @@ class Mupen64PlusEnv(gym.Env):
         # so it attaches to the correct X display; otherwise screenshots
         # come from the wrong place.
         cprint('Calling wx.App() with DISPLAY: %s' % os.environ["DISPLAY"], 'red')
-        wx.App()
+        self.app = wx.App()
         self.screen = wx.ScreenDC()
         time.sleep(2) # Give wx a couple seconds to start up
 


### PR DESCRIPTION
I also had this issue: 
https://github.com/bzier/gym-mupen64plus/issues/12

So, after installing `vglrun` and setting `USE_XVFB: false` in `config.yml` and modifying the code a bit I managed to get it working. I assume the `wx.App()` object should be stored, otherwise the interpreter deletes the object, since there are no references to it. 