### PR TITLE
Replace wx with mss

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Please create issues as you encounter them. Future work and ideas will be captur
 * numpy
 * PyYAML
 * termcolor
-* wx
+* mss
 
 ### Additional Dependencies
 *These dependencies must be manually installed following these instructions.*

--- a/gym_mupen64plus/envs/MarioKart64/mario_kart_env.py
+++ b/gym_mupen64plus/envs/MarioKart64/mario_kart_env.py
@@ -95,7 +95,7 @@ class MarioKartEnv(Mupen64PlusEnv):
                 return self.DEFAULT_STEP_REWARD
 
     def _get_lap(self):
-        pix_arr = self.pixel_array
+        pix_arr = self.numpy_array
         point_a = IMAGE_HELPER.GetPixelColor(pix_arr, 203, 51)
         if point_a in self.LAP_COLOR_MAP:
             return self.LAP_COLOR_MAP[point_a]
@@ -119,7 +119,7 @@ class MarioKartEnv(Mupen64PlusEnv):
             return -1
 
     def _checkpoint(self, checkpoint_points):
-        pix_arr = self.pixel_array
+        pix_arr = self.numpy_array
         colored_dots = map(lambda point: IMAGE_HELPER.GetPixelColor(pix_arr, point[0], point[1]), 
                            checkpoint_points)
         pixel_means = np.mean(colored_dots, 1)
@@ -129,7 +129,7 @@ class MarioKartEnv(Mupen64PlusEnv):
 
     def _evaluate_end_state(self):
         #cprint('Evaluate End State called!','yellow')
-        pix_arr = self.pixel_array
+        pix_arr = self.numpy_array
 
         upper_left = IMAGE_HELPER.GetPixelColor(pix_arr, 19, 19)
         upper_right = IMAGE_HELPER.GetPixelColor(pix_arr, 620, 19)

--- a/gym_mupen64plus/envs/config.yml
+++ b/gym_mupen64plus/envs/config.yml
@@ -18,7 +18,7 @@ OFFSET_Y: 240
 # XVFB config:
 USE_XVFB: true
 XVFB_CMD: Xvfb
-XVFB_DISPLAY: :1
+XVFB_DISPLAY: :0
 TMP_DIR: /dev/shm
 VGLRUN_CMD: vglrun
 

--- a/gym_mupen64plus/envs/config.yml
+++ b/gym_mupen64plus/envs/config.yml
@@ -18,7 +18,7 @@ OFFSET_Y: 240
 # XVFB config:
 USE_XVFB: true
 XVFB_CMD: Xvfb
-XVFB_DISPLAY: :0
+XVFB_DISPLAY: :1
 TMP_DIR: /dev/shm
 VGLRUN_CMD: vglrun
 

--- a/gym_mupen64plus/envs/mupen64plus_env.py
+++ b/gym_mupen64plus/envs/mupen64plus_env.py
@@ -88,12 +88,16 @@ class Mupen64PlusEnv(gym.Env):
             offset_x = config['OFFSET_X']
             offset_y = config['OFFSET_Y']
 
-        self.numpy_array = \
-            np.array(self.mss_grabber.grab({"top": offset_y, 
+        image_array = \
+            np.array(self.mss_grabber.grab({"top": offset_y,
                                             "left": offset_x,
                                             "width": config['SCR_W'],
                                             "height": config['SCR_H']}),
                      dtype=np.uint8)
+
+        # drop the alpha channel and flip red and blue channels (BGRA -> RGB)
+        self.numpy_array = \
+            np.flip(image_array[:, :, :3], 2)
 
         return self.numpy_array
 

--- a/gym_mupen64plus/envs/mupen64plus_env.py
+++ b/gym_mupen64plus/envs/mupen64plus_env.py
@@ -221,6 +221,7 @@ class Mupen64PlusEnv(gym.Env):
                                             shell=False,
                                             stderr=subprocess.STDOUT)
 
+        # TODO: Test and cleanup:
         # May need to initialize this after the DISPLAY env var has been set
         # so it attaches to the correct X display; otherwise screenshots may
         # come from the wrong place. This used to be true when we were using

--- a/gym_mupen64plus/envs/mupen64plus_env.py
+++ b/gym_mupen64plus/envs/mupen64plus_env.py
@@ -17,17 +17,17 @@ from gym.utils import seeding
 
 import numpy as np
 
-import wx
+import mss
 
 
 ###############################################
 class ImageHelper:
 
     def GetPixelColor(self, image_array, x, y):
-        base_pixel = (x + (y * config['SCR_W'])) * 3
-        red = image_array[base_pixel + 0]
-        green = image_array[base_pixel + 1]
-        blue = image_array[base_pixel + 2]
+        base_pixel = image_array[y][x]
+        blue = base_pixel[0]
+        green = base_pixel[1]
+        red = base_pixel[2]
         return (red, green, blue)
 
 
@@ -49,16 +49,12 @@ class Mupen64PlusEnv(gym.Env):
 
     def __init__(self, rom_name):
         self.viewer = None
-        self.screen = None
         self.reset_count = 0
         self.step_count = 0
         self.running = True
-        self.app = None
+        self.mss_grabber = None
         self.episode_over = False
         self.numpy_array = None
-        self.pixel_array = array.array('B', [0] * (config['SCR_W'] *
-                                                   config['SCR_H'] *
-                                                   config['SCR_D']))
         self.controller_server, self.controller_server_thread = self._start_controller_server()
         self.xvfb_process, self.emulator_process = self._start_emulator(rom_name=rom_name)
         self._navigate_menu()
@@ -92,16 +88,12 @@ class Mupen64PlusEnv(gym.Env):
             offset_x = config['OFFSET_X']
             offset_y = config['OFFSET_Y']
 
-        bmp = wx.Bitmap(config['SCR_W'], config['SCR_H'])
-        wx.MemoryDC(bmp).Blit(0, 0,
-                              config['SCR_W'], config['SCR_H'],
-                              self.screen,
-                              offset_x, offset_y)
-        bmp.CopyToBuffer(self.pixel_array)
-
-        self.numpy_array = np.frombuffer(self.pixel_array, dtype=np.uint8)
         self.numpy_array = \
-            self.numpy_array.reshape(config['SCR_H'], config['SCR_W'], config['SCR_D'])
+            np.array(self.mss_grabber.grab({"top": offset_y, 
+                                            "left": offset_x,
+                                            "width": config['SCR_W'],
+                                            "height": config['SCR_H']}),
+                     dtype=np.uint8)
 
         return self.numpy_array
 
@@ -225,13 +217,13 @@ class Mupen64PlusEnv(gym.Env):
                                             shell=False,
                                             stderr=subprocess.STDOUT)
 
-        # Need to initialize this after the DISPLAY env var has been set
-        # so it attaches to the correct X display; otherwise screenshots
-        # come from the wrong place.
-        cprint('Calling wx.App() with DISPLAY: %s' % os.environ["DISPLAY"], 'red')
-        self.app = wx.App()
-        self.screen = wx.ScreenDC()
-        time.sleep(2) # Give wx a couple seconds to start up
+        # May need to initialize this after the DISPLAY env var has been set
+        # so it attaches to the correct X display; otherwise screenshots may
+        # come from the wrong place. This used to be true when we were using
+        # wxPython for screenshots. Untested after switching to mss.
+        cprint('Calling mss.mss() with DISPLAY: %s' % os.environ["DISPLAY"], 'red')
+        self.mss_grabber = mss.mss()
+        time.sleep(2) # Give mss a couple seconds to initialize; also may not be necessary
 
         # Restore the DISPLAY env var
         os.environ["DISPLAY"] = initial_disp

--- a/gym_mupen64plus/envs/mupen64plus_env.py
+++ b/gym_mupen64plus/envs/mupen64plus_env.py
@@ -25,9 +25,9 @@ class ImageHelper:
 
     def GetPixelColor(self, image_array, x, y):
         base_pixel = image_array[y][x]
-        blue = base_pixel[0]
+        red = base_pixel[0]
         green = base_pixel[1]
-        red = base_pixel[2]
+        blue = base_pixel[2]
         return (red, green, blue)
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
 from setuptools import setup
 
 setup(name='gym_mupen64plus',
-      version='0.0.1',
+      version='0.0.2',
       install_requires=['gym>=0.2.3',
                         'numpy>=1.12.0',
                         'PyYAML>=3.12',
                         'termcolor>=1.1.0',
-                        'wx>=3.0.3'])
+                        'mss>=3.0.1'])


### PR DESCRIPTION
Addressing #23 - replacing a heavy and difficult dependency. 

**Notes:**
The existing `wxPython` module provides screenshots in the RGB format, but the `mss` module returns BGRA. The code includes trimming the alpha channel and flipping the array along the appropriate axis to transform this format back into RGB. I have not tested the efficiency of this, but according to the [numpy documentation](https://docs.scipy.org/doc/numpy-dev/reference/generated/numpy.flip.html), the return value is:
> A view of *m* with the entries of axis reversed. Since a view is returned, this operation is done in constant time.

This leads me to believe that the time should be somewhat negligible (again, this is an untested assumption) 