### PR TITLE
Xvfb auto detect

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,12 @@ The environment is currently configured to use [XVFB](https://www.x.org/archive/
 Since the emulator runs off-screen, the environment provides a `render()` call which displays a window with the screen pixels. Each call to `render()` will update this display. For example, an agent can make this call between each `step()`.
 
 ### Connecting to XVFB with VNC
-When calling `reset()`, the environment handles navigating menus and getting the game ready for the next episode. This is a blocking call, so `render()` will not show what is happening in-between. An alternative view into the XVFB display is using VNC. You can connect a VNC server to the XVFB display using the following command (where `:1` matches the configured `XVFB_DISPLAY` value in `config.yml`):
+When calling `reset()`, the environment handles navigating menus and getting the game ready for the next episode. This is a blocking call, so `render()` will not show what is happening in-between. An alternative view into the XVFB display is using VNC. You can connect a VNC server to the XVFB display using the following command:
 ```bash
 x11vnc -display :1 -localhost -forever -viewonly &
 ```
+*(where `:1` matches the chosen display number; the startup output will show "`Using DISPLAY :1`" in blue)*
+
 Then you can use your favorite VNC client to connect to `localhost` to watch the XVFB display in real-time. Note that running the VNC server and client can cause some performance overhead.
 
 ### Running without XVFB

--- a/gym_mupen64plus/envs/config.yml
+++ b/gym_mupen64plus/envs/config.yml
@@ -18,7 +18,6 @@ OFFSET_Y: 240
 # XVFB config:
 USE_XVFB: true
 XVFB_CMD: Xvfb
-XVFB_DISPLAY: :1
 TMP_DIR: /dev/shm
 VGLRUN_CMD: vglrun
 


### PR DESCRIPTION
## Background
When running the environment using Xvfb, the process must be started on an available X Display. If running on your primary X server, the default display of `:0` will already be in use. For this reason, the config file currently defaults to `:1`. However, some people choose to run more than one X server, in which case other display identifiers may also be in use. Additionally, when running in a docker container without any X server, display `:0` is available, and I bumped into problems attempting to use display `:1`.

## Result
This pull request updates the initialization process to attempt to find an available display number for Xvfb to use, eliminating the need for the configuration and hopefully reducing setup time and confusion. It starts with `:0` and increments by 1 until an available display is found.

## TODO
May need to consider adding a configuration override in case this doesn't work for someone. For example, at least a couple people (#15, #31) are using XQuartz on a Mac, which seems to use some strange DISPLAY variable value (e.g. /private/tmp/com.apple.launchd.UQJbDZAVRL/org.macosforge.xquartz:0)