### PR TITLE
Deal with zombie process

### DIFF
--- a/gym_mupen64plus/envs/mupen64plus_env.py
+++ b/gym_mupen64plus/envs/mupen64plus_env.py
@@ -195,7 +195,7 @@ class Mupen64PlusEnv(gym.Env):
 
         xvfb_proc = None
         if config['USE_XVFB']:
-            display_num = -1 #Displaynum hate
+            display_num = -1
             success = False
             # If we couldn't find an open display number after 15 attempts, give up
             while not success and display_num <= 15:
@@ -268,7 +268,7 @@ class Mupen64PlusEnv(gym.Env):
                 self.emulator_process.kill()
             if self.xvfb_process is not None:
                 os.killpg(os.getpgid(self.xvfb_process.pid),signal.SIGTERM)
-                #self.xvfb_process.kill()
+        
         except AttributeError:
             pass # We may be shut down during intialization before these attributes have been set
 

--- a/gym_mupen64plus/envs/mupen64plus_env.py
+++ b/gym_mupen64plus/envs/mupen64plus_env.py
@@ -1,4 +1,5 @@
-from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
+from http.server import BaseHTTPRequestHandler, HTTPServer
+#from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
 
 import abc
 import array
@@ -18,7 +19,8 @@ from gym.utils import seeding
 import numpy as np
 
 import mss
-
+import os
+import signal
 
 ###############################################
 class ImageHelper:
@@ -194,7 +196,7 @@ class Mupen64PlusEnv(gym.Env):
 
         xvfb_proc = None
         if config['USE_XVFB']:
-            display_num = -1
+            display_num = -1 #Displaynum hate
             success = False
             # If we couldn't find an open display number after 15 attempts, give up
             while not success and display_num <= 15:
@@ -209,7 +211,7 @@ class Mupen64PlusEnv(gym.Env):
 
                 cprint('Starting xvfb with command: %s' % xvfb_cmd, 'yellow')
 
-                xvfb_proc = subprocess.Popen(xvfb_cmd, shell=False, stderr=subprocess.STDOUT)
+                xvfb_proc = subprocess.Popen(xvfb_cmd, shell=False, stderr=subprocess.STDOUT, preexec_fn=os.setsid)
 
                 time.sleep(2) # Give xvfb a couple seconds to start up
 
@@ -266,7 +268,8 @@ class Mupen64PlusEnv(gym.Env):
             if self.emulator_process is not None:
                 self.emulator_process.kill()
             if self.xvfb_process is not None:
-                self.xvfb_process.kill()
+                os.killpg(os.getpgid(self.xvfb_process.pid),signal.SIGTERM)
+                #self.xvfb_process.kill()
         except AttributeError:
             pass # We may be shut down during intialization before these attributes have been set
 
@@ -343,7 +346,7 @@ class ControllerHTTPServer(HTTPServer, object):
             self.send_response(resp_code)
             self.send_header("Content-type", "text/plain")
             self.end_headers()
-            self.wfile.write(resp_data)
+            self.wfile.write(resp_data.encode("utf-8"))
 
         def do_GET(self):
 

--- a/gym_mupen64plus/envs/mupen64plus_env.py
+++ b/gym_mupen64plus/envs/mupen64plus_env.py
@@ -18,8 +18,6 @@ from gym.utils import seeding
 import numpy as np
 
 import mss
-import os
-import signal
 
 ###############################################
 class ImageHelper:
@@ -210,7 +208,7 @@ class Mupen64PlusEnv(gym.Env):
 
                 cprint('Starting xvfb with command: %s' % xvfb_cmd, 'yellow')
 
-                xvfb_proc = subprocess.Popen(xvfb_cmd, shell=False, stderr=subprocess.STDOUT, preexec_fn=os.setsid)
+                xvfb_proc = subprocess.Popen(xvfb_cmd, shell=False, stderr=subprocess.STDOUT)
 
                 time.sleep(2) # Give xvfb a couple seconds to start up
 
@@ -267,8 +265,7 @@ class Mupen64PlusEnv(gym.Env):
             if self.emulator_process is not None:
                 self.emulator_process.kill()
             if self.xvfb_process is not None:
-                os.killpg(os.getpgid(self.xvfb_process.pid),signal.SIGTERM)
-        
+                self.xvfb_process.terminate()
         except AttributeError:
             pass # We may be shut down during intialization before these attributes have been set
 

--- a/gym_mupen64plus/envs/mupen64plus_env.py
+++ b/gym_mupen64plus/envs/mupen64plus_env.py
@@ -1,5 +1,4 @@
-from http.server import BaseHTTPRequestHandler, HTTPServer
-#from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
+from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
 
 import abc
 import array
@@ -346,7 +345,7 @@ class ControllerHTTPServer(HTTPServer, object):
             self.send_response(resp_code)
             self.send_header("Content-type", "text/plain")
             self.end_headers()
-            self.wfile.write(resp_data.encode("utf-8"))
+            self.wfile.write(resp_data)
 
         def do_GET(self):
 


### PR DESCRIPTION
On ubuntu 16.04, I have found out that "Xvfb" won't be kill after you call the .kill(). 
This may not be mattered, if there is only single user, 
However, if there are multiple user, the other may not have the permission to create screen0.
Thus, I make a little change for it to really terminate the process.