### PR TITLE
Improve menu navigation & eliminate ghost on retry

### DIFF
--- a/gym_mupen64plus/envs/MarioKart64/mario_kart_env.py
+++ b/gym_mupen64plus/envs/MarioKart64/mario_kart_env.py
@@ -50,18 +50,18 @@ class MarioKartEnv(Mupen64PlusEnv):
         if self.reset_count > 0:
 
             if self.episode_over:
-                self._act(ControllerState.NO_OP, count=59)
+                self._wait(count=59)
                 self._navigate_post_race_menu()
-                self._act(ControllerState.NO_OP, count=40) # Wait for the map select screen
+                self._wait(count=40, wait_for='map select screen')
                 self._navigate_map_select()
-                self._act(ControllerState.NO_OP, count=50) # Wait for race to load
+                self._wait(count=50, wait_for='race to load')
                 self.episode_over = False
             else:
                 self.controller_server.send_controls(ControllerState.NO_OP, start_button=1)
                 self._act(ControllerState.NO_OP)
                 self._press_button(ControllerState.JOYSTICK_DOWN)
                 self._press_button(ControllerState.A_BUTTON)
-                self._act(ControllerState.NO_OP, count=76) # Wait for race to load
+                self._wait(count=76, wait_for='race to load')
 
 
         return super(MarioKartEnv, self)._reset()
@@ -150,31 +150,31 @@ class MarioKartEnv(Mupen64PlusEnv):
             return False
 
     def _navigate_menu(self):
-        self._act(ControllerState.NO_OP, count=10) # Wait for Nintendo screen
+        self._wait(count=10, wait_for='Nintendo screen')
         self._press_button(ControllerState.A_BUTTON)
 
-        self._act(ControllerState.NO_OP, count=68) # Wait for Mario Kart splash screen
+        self._wait(count=68, wait_for='Mario Kart splash screen')
         self._press_button(ControllerState.A_BUTTON)
 
-        self._act(ControllerState.NO_OP, count=68) # Wait for Game Select screen
+        self._wait(count=68, wait_for='Game Select screen')
         self._navigate_game_select()
 
-        self._act(ControllerState.NO_OP, count=14) # Wait for Player Select screen
+        self._wait(count=14, wait_for='Player Select screen')
         self._navigate_player_select()
 
-        self._act(ControllerState.NO_OP, count=31) # Wait for Map Select screen
+        self._wait(count=31, wait_for='Map Select screen')
         self._navigate_map_select()
 
-        self._act(ControllerState.NO_OP, count=50) # Wait for race to load
+        self._wait(count=50, wait_for='race to load')
 
     def _navigate_game_select(self):
         # Select number of players (1 player highlighted by default)
         self._press_button(ControllerState.A_BUTTON)
-        self._act(ControllerState.NO_OP, count=3) # Wait for animation
+        self._wait(count=3, wait_for='animation')
 
         # Select GrandPrix or TimeTrials (GrandPrix highlighted by default - down to switch to TimeTrials)
         self._press_button(ControllerState.JOYSTICK_DOWN)
-        self._act(ControllerState.NO_OP, count=3) # Wait for animation
+        self._wait(count=3, wait_for='animation')
 
         # Select TimeTrials
         self._press_button(ControllerState.A_BUTTON)
@@ -229,7 +229,7 @@ class MarioKartEnv(Mupen64PlusEnv):
     def _navigate_post_race_menu(self):
         # Times screen
         self._press_button(ControllerState.A_BUTTON)
-        self._act(ControllerState.NO_OP, count=13)
+        self._wait(count=13)
 
         # Post race menu (previous choice selected by default)
         # - Retry

--- a/gym_mupen64plus/envs/mupen64plus_env.py
+++ b/gym_mupen64plus/envs/mupen64plus_env.py
@@ -83,6 +83,9 @@ class Mupen64PlusEnv(gym.Env):
         for _ in itertools.repeat(None, count):
             self.controller_server.send_controls(action)
 
+    def _wait(self, count=1, wait_for='Unknown'):
+        self._act(ControllerState.NO_OP, count=count)
+
     def _press_button(self, button):
         self._act(button) # Press
         self._act(ControllerState.NO_OP) # and release

--- a/gym_mupen64plus/envs/mupen64plus_env.py
+++ b/gym_mupen64plus/envs/mupen64plus_env.py
@@ -3,6 +3,7 @@ from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
 import abc
 import array
 import inspect
+import itertools
 import json
 import os
 import subprocess
@@ -79,7 +80,7 @@ class Mupen64PlusEnv(gym.Env):
         return obs, reward, self.episode_over, {}
 
     def _act(self, action, count=1):
-        for i in range(count):
+        for _ in itertools.repeat(None, count):
             self.controller_server.send_controls(action)
 
     def _press_button(self, button):
@@ -254,8 +255,6 @@ class Mupen64PlusEnv(gym.Env):
         cprint('Calling mss.mss() with DISPLAY %s' % os.environ["DISPLAY"], 'red')
         self.mss_grabber = mss.mss()
         time.sleep(2) # Give mss a couple seconds to initialize; also may not be necessary
-
-        time.sleep(30) # TODO: Remove... added for testing (give time to connect with VNC client)
 
         # Restore the DISPLAY env var
         os.environ["DISPLAY"] = initial_disp

--- a/gym_mupen64plus/envs/mupen64plus_env.py
+++ b/gym_mupen64plus/envs/mupen64plus_env.py
@@ -70,13 +70,21 @@ class Mupen64PlusEnv(gym.Env):
 
     def _step(self, action):
         #cprint('Step %i: %s' % (self.step_count, action), 'green')
-        self.controller_server.send_controls(action)
+        self._act(action)
         obs = self._observe()
         self.episode_over = self._evaluate_end_state()
         reward = self._get_reward()
 
         self.step_count += 1
         return obs, reward, self.episode_over, {}
+
+    def _act(self, action, count=1):
+        for i in range(count):
+            self.controller_server.send_controls(action)
+
+    def _press_button(self, button):
+        self._act(button) # Press
+        self._act(ControllerState.NO_OP) # and release
 
     def _observe(self):
         #cprint('Observe called!', 'yellow')
@@ -247,6 +255,8 @@ class Mupen64PlusEnv(gym.Env):
         self.mss_grabber = mss.mss()
         time.sleep(2) # Give mss a couple seconds to initialize; also may not be necessary
 
+        time.sleep(30) # TODO: Remove... added for testing (give time to connect with VNC client)
+
         # Restore the DISPLAY env var
         os.environ["DISPLAY"] = initial_disp
         cprint('Changed back to DISPLAY %s' % os.environ["DISPLAY"], 'red')
@@ -262,7 +272,7 @@ class Mupen64PlusEnv(gym.Env):
     def _kill_emulator(self):
         #cprint('Kill Emulator called!', 'yellow')
         try:
-            self.controller_server.send_controls(ControllerState.NO_OP)
+            self._act(ControllerState.NO_OP)
             if self.emulator_process is not None:
                 self.emulator_process.kill()
             if self.xvfb_process is not None:


### PR DESCRIPTION
Menu navigation is now defined as modular pieces and more discrete controller actions, rather than confusing frame counts. This allows for each piece to be reused when entering each menu from a different starting point (e.g initially selecting the map versus course change from the post-race menu).

Also, the post-race menu navigation now chooses 'course change' rather than 'retry' in order to prevent having the ghost racer in the next race. This causes problems with progress detection (see #25).