### PR TITLE
fix None check

### DIFF
--- a/gym_mupen64plus/envs/mupen64plus_env.py
+++ b/gym_mupen64plus/envs/mupen64plus_env.py
@@ -166,7 +166,7 @@ class Mupen64PlusEnv(gym.Env):
 
     def _stop_controller_server(self):
         #cprint('Stop Controller Server called!', 'yellow')
-        if self.controller_server is not None:
+        if hasattr(self, 'controller_server'):
             self.controller_server.shutdown()
 
     def _start_emulator(self,


### PR DESCRIPTION
The gym crash during the initialisation of the controller server for me which triggered another failure. This stops the second exception for me and I believe this is the correct way to check for an unassigned attribute in python.