### PR TITLE
Temp fix for gym breaking changes

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
 - wheel=0.29.0=py27_0
 - zlib=1.2.8=3
 - pip:
-  - gym>=0.7.4
+  - gym==0.7.4
   - numpy>=1.12.0
   - PyYAML>=3.12
   - termcolor>=1.1.0

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(name='gym_mupen64plus',
       version='0.0.2',
-      install_requires=['gym>=0.2.3',
+      install_requires=['gym==0.7.4',
                         'numpy>=1.12.0',
                         'PyYAML>=3.12',
                         'termcolor>=1.1.0',


### PR DESCRIPTION
Since the gym platform made breaking changes in 0.9.6, this change will lock the dependency at the known working version 0.7.4. Issue #41 is open to track the upgrade to the latest version.