### PR TITLE
Containerize project

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+Dockerfile
+.dockerignore
+.git
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,83 @@
+################################################################
+FROM ubuntu:xenial-20170915 AS base
+
+
+# Setup environment variables in a single layer
+ENV \
+    # Prevent dpkg from prompting for user input during package setup
+    DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
+    # mupen64plus will be installed in /usr/games/; add to the $PATH
+    PATH=$PATH:/usr/games/ \
+    # Set default DISPLAY
+    DISPLAY=:0
+
+
+################################################################
+FROM base AS buildstuff
+
+RUN apt-get update && \
+    apt-get install -y \
+        build-essential dpkg-dev libwebkitgtk-dev libjpeg-dev libtiff-dev libgtk2.0-dev \
+        libsdl1.2-dev libgstreamer-plugins-base0.10-dev libnotify-dev freeglut3 freeglut3-dev \
+        libjson-c2 libjson-c-dev \
+        git
+
+# clone, build, and install the input bot
+# (explicitly specifying commit hash to attempt to guarantee behavior within this container)
+WORKDIR /src/mupen64plus-src
+RUN git clone https://github.com/mupen64plus/mupen64plus-core && \
+        cd mupen64plus-core && \
+        git reset --hard 12d136dd9a54e8b895026a104db7c076609d11ff && \
+    cd .. && \
+    git clone https://github.com/kevinhughes27/mupen64plus-input-bot && \
+        cd mupen64plus-input-bot && \
+        git reset --hard 40eff412eca6491acb7f70932b87b404c9c3ef70 && \
+    make all && \
+    make install
+
+
+################################################################
+FROM base
+
+
+# Update package cache and install dependencies
+RUN apt-get update && \
+    apt-get install -y \
+        python python-pip python-setuptools python-dev \
+        wget \
+        xvfb libxv1 x11vnc \
+        imagemagick \
+        mupen64plus \
+        nano \
+        ffmpeg
+
+# Upgrade pip
+RUN pip install --upgrade pip 
+
+# install VirtualGL (provides vglrun to allow us to run the emulator in XVFB)
+# (Check for new releases here: https://github.com/VirtualGL/virtualgl/releases)
+ENV VIRTUALGL_VERSION=2.5.2
+RUN wget "https://sourceforge.net/projects/virtualgl/files/${VIRTUALGL_VERSION}/virtualgl_${VIRTUALGL_VERSION}_amd64.deb" && \
+    apt install ./virtualgl_${VIRTUALGL_VERSION}_amd64.deb && \
+    rm virtualgl_${VIRTUALGL_VERSION}_amd64.deb
+
+# Copy compiled input plugin from buildstuff layer
+COPY --from=buildstuff /usr/local/lib/mupen64plus/mupen64plus-input-bot.so /usr/local/lib/mupen64plus/
+
+# Copy the gym environment (current directory)
+COPY . /src/gym-mupen64plus
+# Copy the Super Smash Bros. save file to the mupen64plus save directory
+# mupen64plus expects a specific filename, hence the awkward syntax and name
+COPY ["./gym_mupen64plus/envs/Smash/smash.sra", "/root/.local/share/mupen64plus/save/Super Smash Bros. (U) [!].sra"]
+
+# Install requirements & this package
+WORKDIR /src/gym-mupen64plus
+RUN pip install -e .
+
+# Declare ROMs as a volume for mounting a host path outside the container
+VOLUME /src/gym-mupen64plus/gym_mupen64plus/ROMs/
+
+WORKDIR /src
+
+# Expose the default VNC port for connecting with a client/viewer outside the container
+EXPOSE 5900

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This project is an [OpenAI Gym](https://github.com/openai/gym/) environment wrapper for the [Mupen64Plus](http://www.mupen64plus.org/) N64 emulator. The goal of this project is to provide a platform for reinforcement learning agents to be able to easily interface with N64 games using the OpenAI gym library. This should allow for easier adaptation of existing agents that have been built using the gym library to play Atari games, for example.
 
-Currently, only MarioKart64 and SuperSmashBros have been wrapped, but the core environment has been built to support any games. This top-level README will be used to describe the basic setup instructions, architecture of the environment, etc. Each game that gets wrapped will have its own README file within its respective subdirectory. This top-level README will link to each of the games' README file as well.
+Currently, only MarioKart64 and SuperSmashBros have been wrapped, but the core environment has been built to support any game. This top-level README will be used to describe the basic setup instructions, architecture of the environment, etc. Each game that gets wrapped will have its own README file within its respective subdirectory. This top-level README will link to each of the games' README file as well.
 
 #### Thanks:
 Many of the core concepts for this wrapper were borrowed/adapted directly from [@kevinhughes27](https://github.com/kevinhughes27)'s fantastic [TensorKart](https://github.com/kevinhughes27/TensorKart) project (self-driving MarioKart with TensorFlow). A huge thanks goes out to him for inspiring the foundation of this project.
@@ -12,158 +12,87 @@ Many of the core concepts for this wrapper were borrowed/adapted directly from [
 
 Please create issues as you encounter them. Future work and ideas will be captured as issues as well, so if you have any ideas of things you'd like to see, please add them. Also, feel free to fork this repository and improve upon it. If you come up with something you'd like to see incorporated, submit a pull request. Adding support for additional games would be a great place to start. If you do decide to implement support for a game, please create an issue mentioning what game you are working on. This will help organize the project and prevent duplicate work.
 
-
 ## Setup
 
-### Python Dependencies
-*If you follow the installation steps below, these dependencies will be resolved automatically.*
-* Python 2.7 or Python 3.x (tested in 2.7.13 and 3.6.0)
-* gym
-* numpy
-* PyYAML
-* termcolor
-* mss
+The easiest, cleanest, most consistent way to get up and running with this project is via [`Docker`](https://docs.docker.com/). These instructions will focus on that approach.
 
-### Additional Dependencies
-*These dependencies must be manually installed following these instructions.*
-* Mupen64Plus
-    ```bash
-    #!/bin/bash
-    sudo apt-get install mupen64plus
+### With Docker
+
+1. Run the following command to build the project's docker image
+
+    > You should substitute the placeholders between `< >` with your own values.
+
+    ```sh
+    docker build -t <image_name>:<tag> .
+    ```
+    ```sh
+    # Example:
+    docker build -t bz/gym-mupen64plus:0.0.5 .
     ```
 
-* OpenCV - needed for Super Smash Bros only
-    ```bash
-    sudo apt-get install python-opencv
-    ```
+    ### That's it!
 
-* VirtualGL- Available at https://sourceforge.net/projects/virtualgl/files/
-    * On RPM based systems, install with
-        ```bash
-        rpm -i VirtualGL*.rpm
-        ```
-    * On Debian based systems, install with
-        ```bash
-        dpkg -i VirtualGL*.deb
-        ```
+    ...wait... that's it??
 
-* mupen64plus-input-bot (these instructions may have changed; the most current are on that project's [page](https://github.com/kevinhughes27/mupen64plus-input-bot))
-    ```bash
-    #!/bin/bash
-    sudo apt-get install libjson-c-dev libjson-c2
-    mkdir mupen64plus-src && cd "$_"
-    git clone https://github.com/mupen64plus/mupen64plus-core
-    git clone https://github.com/kevinhughes27/mupen64plus-input-bot
-    cd mupen64plus-input-bot
-    make all
-    sudo make install
-    ```
+    Yup... Ah, the beauty of Docker.
 
-* One or more N64 ROMs (see the [Games](#games) section below)
-
-### Installation
-
-Setting up the dependencies can be accomplished in many different ways. Two methods are provided here:
-
-#### Method #1: Directly installing via `pip`:
-To simply install the necessary dependencies into your system, use the following commands.
-
-*Note that this may upgrade/replace existing packages you may already have installed.*
-
-```bash
-#!/bin/bash
-cd gym-mupen64plus
-
-# Install the gym-mupen64plus package (and dependencies)
-pip install -e .
-```
-
-#### Method #2: Installing in a [conda environment](http://conda.pydata.org/docs/using/envs.html):
-To minimize disruption to your system and to prevent version conflicts with libraries you may already have installed, you can set up a conda environment with the following commands.
-
-```bash
-#!/bin/bash
-cd gym-mupen64plus
-
-# Create the conda environment with all the necessary requirements
-conda env create -f environment.yml
-
-# Activate the new environment
-source activate gym-mupen64plus
-
-# Install the gym-mupen64plus package in the new environment
-pip install -e .
-```
-
-### Configuration
-
-A configuration file ([`config.yml`](gym_mupen64plus/envs/config.yml)) has been provided for the core wrapper where the primary settings are stored. This configuration may vary on your system, so please take a look at the available settings and adjust as necessary.
-
-Additionally, each game environment may specify configuration values which will be stored in a separate config file in the game's specific subdirectory (see each game's README for those details). The game environment may also override any of the base config values by specifying the same setting name and passing the loaded config dictionary to the base environment init method.
-
-
-## XVFB
-
-The environment is currently configured to use [XVFB](https://www.x.org/archive/X11R7.6/doc/man/man1/Xvfb.1.xhtml) by default. This allows the emulator to run behind-the-scenes and simplifies configuration. The config file includes a flag to turn this behavior on/off (see below for details running with the flag turned off).
-
-### Viewing the emulator in XVFB
-Since the emulator runs off-screen, the environment provides a `render()` call which displays a window with the screen pixels. Each call to `render()` will update this display. For example, an agent can make this call between each `step()`.
-
-### Connecting to XVFB with VNC
-When calling `reset()`, the environment handles navigating menus and getting the game ready for the next episode. This is a blocking call, so `render()` will not show what is happening in-between. An alternative view into the XVFB display is using VNC. You can connect a VNC server to the XVFB display using the following command:
-```bash
-x11vnc -display :1 -localhost -forever -viewonly &
-```
-*(where `:1` matches the chosen display number; the startup output will show "`Using DISPLAY :1`" in blue)*
-
-Then you can use your favorite VNC client to connect to `localhost` to watch the XVFB display in real-time. Note that running the VNC server and client can cause some performance overhead.
-
-### Running without XVFB
-If XVFB is turned off, the emulator will run in your default X display manager. As a result, the display manager positions the emulator window (we have no control over where the window is positioned). This means that you will need to configure the offset values to ensure we are capturing the correct portion of the screen. Additionally, it means the emulator must remain the top-most window for the entirety of the session. Otherwise, the AI agent will see whatever is on-screen rather than the emulator window.
-
+### Without Docker
+* :(
+  > It is possible to run without Docker, but there isn't a compelling reason to and it just introduces a significant amount of setup work and potential complications.
+  >
+  > **`Fair warning:`** I likely will ***not*** be testing manual setup or maintaining its documentation going forward so it may become stale over time.
+  >
+  > However, if you really do want to, here are the [old instructions](docs/manual_setup.md).
 
 ## Example Agents
 
 ### Simple Test:
 A simple example to test if the environment is up-and-running:
+```
+docker run -it \
+  --name test-gym-env \
+  -p 5900 \
+  --mount source="$(MY_ROM_PATH)",target=/src/gym-mupen64plus/gym_mupen64plus/ROMs,type=bind \
+  bz/gym-mupen64plus:0.0.5 \ # This should match the image & tag you used during setup
+  python verifyEnv.py
+```
+
 ```python
 #!/bin/python
 import gym, gym_mupen64plus
 
-def main():
-    env = gym.make('Mario-Kart-Luigi-Raceway-v0')
-    env.reset()
-    env.render()
+env = gym.make('Mario-Kart-Luigi-Raceway-v0')
+env.reset()
 
-    for i in range(18):
-        (obs, rew, end, info) = env.step([0, 0, 0, 0, 0]) # NOOP until green light
-        env.render()
+for i in range(88):
+    (obs, rew, end, info) = env.step([0, 0, 0, 0, 0]) # NOOP until green light
 
-    for i in range(20):
-        (obs, rew, end, info) = env.step([0, 0, 1, 0, 0]) # Drive straight
-        env.render()
+for i in range(100):
+    (obs, rew, end, info) = env.step([0, 0, 1, 0, 0]) # Drive straight
 
-    raw_input("Press <enter> to exit... ")
+raw_input("Press <enter> to exit... ")
 
-    env.close()
-
-if __name__ == '__main__':
-    main()
+env.close()
 ```
 
-### AI Agent:
-The original inspiration for this project has now been updated to take advantage of this gym environment. It is an example of using supervised learning (hopefully soon adding reinforcement learning) to train an AI Agent that is capable of interacting with the environment. It utilizes the TensorFlow library for its machine learning. Check out TensorKart [here](https://github.com/kevinhughes27/TensorKart).
+### AI Agent (supervised learning):
+The original inspiration for this project has now been updated to take advantage of this gym environment. It is an example of using supervised learning to train an AI Agent that is capable of interacting with the environment (Mario Kart). It utilizes the TensorFlow library for its machine learning. Check out TensorKart [here](https://github.com/kevinhughes27/TensorKart).
+
+
+### AI Agent (reinforcement learning):
+An adaptation of the A3C algorithm has been applied to this environment (Mario Kart) and is capable of training from scratch (zero knowledge) to successfully finish races. Check out that agent [here](https://github.com/bzier/universe-starter-agent/tree/mario-kart-agent).
 
 
 ## Games
 
 *Links to ROM files will not be included here. Use your ninja skills as appropriate.*
 
-ROM files should be placed in `./gym_mupen64plus/ROMs/`.
+ROM files can be placed in `./gym_mupen64plus/ROMs/`.
 
 Here is a list of games that have been wrapped. Each game may support multiple 'modes' with different levels or missions configured. See each of the games' pages for more details.
 * [MarioKart64](gym_mupen64plus/envs/MarioKart64/README.md)
 * [Super Smash Bros](gym_mupen64plus/envs/Smash/README.md)
+
 
 ## Architecture
 
@@ -189,7 +118,7 @@ The core `Mupen64PlusEnv` class has been built to handle many of the details of 
 
 * `_observe()` grabs a screenshot of the emulator window and returns the pixel data as a numpy array.
 
-* `_render()` currently doesn't do anything. Eventually the project will support xvfb and this method will be used to make the emulator visible, when specified.
+* `_render()` returns the image or opens a viewer depending on the specified mode. Note that calling `_render()` inside a container currently interferes with the emulator display causing the screen to appear frozen, and should be avoided.
 
 * `_close()` shuts down the environment: stops the emulator, and stops the controller server.
 

--- a/docs/manual_setup.md
+++ b/docs/manual_setup.md
@@ -1,0 +1,93 @@
+## Manual Setup
+
+> **`Fair warning:`** I likely will ***not*** be testing manual setup or maintaining its documentation going forward so it may become stale over time. For the current setup documentation using Docker, go [here](../README.md#with-docker)
+
+### Python Dependencies
+*If you follow the installation steps below, these dependencies will be resolved automatically.*
+* Python 2.7
+* gym
+* numpy
+* PyYAML
+* termcolor
+* mss
+
+### Additional Dependencies
+*These dependencies must be manually installed following these instructions.*
+* Mupen64Plus
+    ```bash
+    #!/bin/bash
+    sudo apt-get install mupen64plus
+    ```
+
+* mupen64plus-input-bot
+    ```bash
+    #!/bin/bash
+    mkdir mupen64plus-src && cd "$_"
+    git clone https://github.com/mupen64plus/mupen64plus-core
+    git clone https://github.com/kevinhughes27/mupen64plus-input-bot
+    cd mupen64plus-input-bot
+    make all
+    sudo make install
+    ```
+
+* One or more N64 ROMs (see the [Games](#games) section below)
+
+### Installation
+
+Setting up the dependencies can be accomplished in many different ways. Two methods are provided here:
+
+#### Method #1: Directly installing via `pip`:
+To simply install the necessary dependencies into your system, use the following commands.
+
+*Note that this may upgrade/replace existing packages you may already have installed.*
+
+```bash
+#!/bin/bash
+cd gym-mupen64plus
+
+# Install the gym-mupen64plus package (and dependencies)
+pip install -e .
+```
+
+#### Method #2: Installing in a [conda environment](http://conda.pydata.org/docs/using/envs.html):
+To minimize disruption to your system and to prevent version conflicts with libraries you may already have installed, you can set up a conda environment with the following commands.
+
+```bash
+#!/bin/bash
+cd gym-mupen64plus
+
+# Create the conda environment with all the necessary requirements
+conda env create -f environment.yml
+
+# Activate the new environment
+source activate gym-mupen64plus
+
+# Install the gym-mupen64plus package in the new environment
+pip install -e .
+```
+
+### Configuration
+
+A configuration file ([`config.yml`](gym_mupen64plus/envs/config.yml)) has been provided for the core wrapper where the primary settings are stored. This configuration may vary on your system, so please take a look at the available settings and adjust as necessary.
+
+Additionally, each game environment may specify configuration values which will be stored in a separate config file in the game's specific subdirectory (see each game's README for those details).
+
+
+## XVFB
+
+The environment is currently configured to use [XVFB](https://www.x.org/archive/X11R7.6/doc/man/man1/Xvfb.1.xhtml) by default. This allows the emulator to run behind-the-scenes and simplifies configuration. The config file includes a flag to turn this behavior on/off (see below for details running with the flag turned off). 
+
+### Viewing the emulator in XVFB
+Since the emulator runs off-screen, the environment provides a `render()` call which displays a window with the screen pixels. Each call to `render()` will update this display. For example, an agent can make this call between each `step()`.
+
+### Connecting to XVFB with VNC
+When calling `reset()`, the environment handles navigating menus and getting the game ready for the next episode. This is a blocking call, so `render()` will not show what is happening in-between. An alternative view into the XVFB display is using VNC. You can connect a VNC server to the XVFB display using the following command:
+```bash
+x11vnc -display :1 -localhost -forever -viewonly &
+```
+*(where `:1` matches the chosen display number; the startup output will show "`Using DISPLAY :1`" in blue)*
+
+Then you can use your favorite VNC client to connect to `localhost` to watch the XVFB display in real-time. Note that running the VNC server and client can cause some performance overhead.
+
+### Running without XVFB
+If XVFB is turned off, the emulator will run in your default X display manager. As a result, the display manager positions the emulator window (we have no control over where the window is positioned). This means that you will need to configure the offset values to ensure we are capturing the correct portion of the screen. Additionally, it means the emulator must remain the top-most window for the entirety of the session. Otherwise, the AI agent will see whatever is on-screen rather than the emulator window.


### PR DESCRIPTION
To ease installation, setup, and usage, it is highly recommended to run gym-mupen64plus in a Docker container. That way, the code can easily be run anywhere that supports Docker instead of trying to replicate a supported environment. Most of the context here has been discussed in #68, but the core of this update is the following:

- Rebase the `dockerize` branch created by @bzier on top of `master` to get the latest changes (including support for Super Smash Bros.).
- Update the README to reflect the discovery that using `render()` inside of a container makes the screen appear frozen while running and should be avoided.
- Include `ffmpeg` as one of the installed packages in the Docker image to support recording runs using gym's `Monitor` wrapper.
- Directly copy the provided `smash.sra` file to mupen64plus' game save location using the expected filename to unlock everything in Super Smash Bros.

Closes #68

Signed-Off-By: Robert Clark <robdclark@outlook.com>