### PR TITLE
Ensure libjson-c.so.2 makes it to the final Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,8 @@ RUN apt-get update && \
         imagemagick \
         mupen64plus \
         nano \
-        ffmpeg
+        ffmpeg \
+        libjson-c2 libjson-c-dev
 
 # Upgrade pip
 RUN pip install --upgrade pip 

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN apt-get update && \
         mupen64plus \
         nano \
         ffmpeg \
-        libjson-c2 libjson-c-dev
+        libjson-c2
 
 # Upgrade pip
 RUN pip install --upgrade pip 


### PR DESCRIPTION
Solves Emulator closed with code: 12 issue from https://github.com/bzier/gym-mupen64plus/issues/77

Without this code, libjson-c.so.2 is not in final docker image.

I'm new to Docker and the from/as syntax.
If there is a better way to do this, let me know! 